### PR TITLE
Support for quotes in values

### DIFF
--- a/CsvParser/CsvReader.cs
+++ b/CsvParser/CsvReader.cs
@@ -180,8 +180,11 @@ namespace CsvParser
                             case Chunk.TypeEnum.quotes:
                                 if (row.LastColumnSize > 0)
                                     throw new InvalidDataException($"Data found before quotation marks, at: {_rowCnt}");
-                                _currentChunkStart = part.Value + withQuotesNone;
-                                state = State.qdata;
+                                if (part.Value - _currentChunkStart == 0)
+                                {
+                                    _currentChunkStart = part.Value + withQuotesNone;
+                                    state = State.qdata;
+                                }
                                 break;
                             case Chunk.TypeEnum.comma:
                                 row.AddColumnData(_currentChunk, _currentChunkStart, part.Value - _currentChunkStart);


### PR DESCRIPTION
Hi,

I'm having some problems with CsvParser library. 
I need to parse some CSV files from a third party, but there are double quotes in the values.
For example: `a,b"c"d,e`

These CSV files may not be standard, but I expected CsvParser to handle it more compliantly.

Here are some tests I did:
```
b"c
=>
["c"]
```
```
a,b"c
=>
["a", "c"]
```
```
a,b"c,d
=>
["a", "c,d"]
```
```
a,b"c"d,e
=>
Unexpected data between quotes
```

After my modification:
```
b"c
=>
["b\"c"]
```
```
a,b"c
=>
["a", "b\"c"]
```
```
a,b"c,d
=>
["a", "b\"c", "d"]
```
```
a,b"c"d,e
=>
["a", "b\"c\"d", "e"]
```

Can you please review and merge my change?
Thanks.